### PR TITLE
Force touch to peek caption

### DIFF
--- a/DevelopmentAssets/Development.xcassets/yosemite.dataset/Contents.json
+++ b/DevelopmentAssets/Development.xcassets/yosemite.dataset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "data" : [
+    {
+      "filename" : "engagement-54.jpg",
+      "idiom" : "universal",
+      "universal-type-identifier" : "public.jpeg"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DevelopmentAssets/Development.xcassets/yosemite.dataset/engagement-54.jpg
+++ b/DevelopmentAssets/Development.xcassets/yosemite.dataset/engagement-54.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f938ef77d46321c5200863b8c9cb697e0e7a874d6a3290ea263ea6d339abbaeb
+size 7656989

--- a/SetCap/SwiftUIPicker/PhotoPickerCell.swift
+++ b/SetCap/SwiftUIPicker/PhotoPickerCell.swift
@@ -23,8 +23,8 @@ struct PhotoPickerCell: View {
         GeometryReader { proxy in
             ZStack {
                 if let image = image {
+                    let loader = ImageLoader(assetId: assetLocalId, photoService: photoLibraryService)
                     NavigationLink {
-                        let loader = ImageLoader(assetId: assetLocalId, photoService: photoLibraryService)
                         CaptionView(loader: loader)
                             .environment(\.templateActions, shareActions(assetId: assetLocalId))
                     } label: {
@@ -36,6 +36,26 @@ struct PhotoPickerCell: View {
                                 height: proxy.size.width
                             )
                             .clipped()
+                    }.contextMenu(menuItems: {
+                        NavigationLink {
+                            CaptionView(loader: loader)
+                                .environment(\.templateActions, shareActions(assetId: assetLocalId))
+                        } label: {
+                            Text("open")
+                        }
+                        Button("Copy last used caption (\"emoji\")") {
+
+                        }
+                        Button("Post to instagram with last used emoji") {
+
+                        }
+                        Button("Share") {
+
+                        }
+                    }) {
+
+                            CaptionPreview(assetId: assetLocalId)
+                                .environmentObject(photoLibraryService)
                     }
                 } else {
                     Rectangle()
@@ -83,6 +103,39 @@ struct PhotoPickerCell: View {
 
         return actions
     }
+}
+
+struct CaptionPreview: View {
+    @State private var imageMetadata: ImageMetadata?
+    @State private var image: UIImage?
+    @EnvironmentObject var photoLibraryService: PhotoLibraryService
+
+    let assetId: String
+
+    var body: some View {
+        VStack {
+            if let imageMetadata = imageMetadata, let image = image {
+                let name = Template.emoji.name
+                let caption = CaptionBuilder.build(.emoji, with: imageMetadata)
+
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .fixedSize(horizontal: false, vertical: true)
+                TemplateView(templateTitle: name, caption: caption)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.bottom, 140)
+            } else {
+                CapSetLoadingIndicator()
+            }
+        }.task {
+            if let data = try? await photoLibraryService.fetchImage(byLocalIdentifier: assetId) {
+                imageMetadata = ImageMetadata(imageData: data)
+                image = UIImage(data: data)
+            }
+        }
+    }
+
 }
 
 extension PhotoPickerCell {

--- a/SetCapCore/UI/TemplateView.swift
+++ b/SetCapCore/UI/TemplateView.swift
@@ -27,6 +27,11 @@ public struct TemplateView: View {
     public typealias Actions = OrderedSet<Action>
     public typealias ShareHandler = ((_ caption: String) -> Void)
 
+    public init(templateTitle: String, caption: String) {
+        self.templateTitle = templateTitle
+        self.caption = caption
+    }
+
     public enum Action: Hashable, Identifiable {
 
         public static func == (lhs: TemplateView.Action, rhs: TemplateView.Action) -> Bool {

--- a/SetCapCore/UI/TemplateView.swift
+++ b/SetCapCore/UI/TemplateView.swift
@@ -22,14 +22,16 @@ public extension EnvironmentValues {
 public struct TemplateView: View {
     let templateTitle: String
     let caption: String
+    let addCopyAction: Bool
     @Environment(\.templateActions) var actions: Actions?
 
     public typealias Actions = OrderedSet<Action>
     public typealias ShareHandler = ((_ caption: String) -> Void)
 
-    public init(templateTitle: String, caption: String) {
+    public init(templateTitle: String, caption: String, addCopyAction: Bool = true) {
         self.templateTitle = templateTitle
         self.caption = caption
+        self.addCopyAction = addCopyAction
     }
 
     public enum Action: Hashable, Identifiable {
@@ -83,10 +85,13 @@ public struct TemplateView: View {
         case copy(handler: ShareHandler)
     }
 
-    private func buildActions() -> OrderedSet<Action> {
-        var actions: OrderedSet<Action> = [.copy(handler: { caption in
-            UIPasteboard.general.string = caption
-        })]
+    private func buildActions() -> Actions {
+        var actions = Actions()
+        if addCopyAction {
+            actions.append(.copy(handler: { caption in
+                UIPasteboard.general.string = caption
+            }))
+        }
         actions.append(contentsOf: self.actions ?? [])
         return actions
     }
@@ -94,38 +99,35 @@ public struct TemplateView: View {
     public var body: some View {
 
         VStack(alignment: .leading) {
-            HStack(alignment: .bottom) {
-                Text(templateTitle)
-                    .fontWeight(.medium)
-                    .foregroundColor(.primary)
-                    .padding(.bottom, 8)
-                Spacer()
-                ForEach(buildActions()) { action in
-                    Button {
-                        action.handler(caption)
-                    } label: {
-                        Label(title: {
-                            Text("unused")
-                        }, icon: {
-                            action.label
-                        })
-                        .labelStyle(.iconOnly)
+            VStack(alignment: .leading) {
+                HStack(alignment: .bottom) {
+                    Text(templateTitle)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+                    Spacer()
+                    ForEach(buildActions()) { action in
+                        Button {
+                            action.handler(caption)
+                        } label: {
+                            Label(title: {
+                                Text("unused")
+                            }, icon: {
+                                action.label
+                            })
+                            .labelStyle(.iconOnly)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
                 }
-            }
-            .padding([.top, .leading, .trailing])
+                Text(caption)
 
-            Text(caption)
-                .padding([.leading, .bottom])
-
+            }.padding()
         }
         .overlay(
             RoundedRectangle(cornerRadius: 16)
                 .stroke(.secondary, lineWidth: 0.5)
         )
-        .padding(.horizontal, 16)
     }
 }
 


### PR DESCRIPTION
Annoyingly I couldn't get layout to happen nicely for horizontal images... very irritating. 

When set to `.aspectFit`, horizontal images and the caption will fit nicely in the preview but the image will not take up the full available width as I want it to. Like this: 
<img width="200" alt="Screenshot 2023-08-27 at 17 10 06" src="https://github.com/ky1ejs/SetCap/assets/3501212/3fc94c36-f695-4e37-940d-c7e5a9a842c7">

Portrait images come out a bit better:
<img width="200" alt="Screenshot 2023-08-27 at 17 10 06" src="https://github.com/ky1ejs/SetCap/assets/3501212/cd2c5ae2-42da-4ebd-8c28-79242ebde449">

If I set the image to `.aspectFill`, it comes out like this:
<img width="200" alt="Screenshot 2023-08-27 at 17 10 29" src="https://github.com/ky1ejs/SetCap/assets/3501212/7b3601ed-2f30-44dc-82aa-8d2df2ec5c23">


And after tweaking a bit I got this, but due to the aspect ration this image is super zoomed in:
<img width="200" alt="Screenshot 2023-08-27 at 17 10 06" src="https://github.com/ky1ejs/SetCap/assets/3501212/3f52b79a-e7f1-4e8b-88c8-427c42bcfb88">


## Attempted Approaches
- Playing with `maxWidth`/ `maxHeight`
- Playing with `GeometryReader`
- Playing with `fixedSize()`

Nothing worked... For whatever reason, with the view will not expand vertically to allow the image to take up the full width. 

In autolayout I'd imagine you'd set the compression resistance and that should take you to where you want to go.

Alternative approach is to try [this](https://gist.github.com/SpectralDragon/e1c01388db09752eac790ae23f1d4587), found via [this SO answer](https://stackoverflow.com/questions/63131547/show-a-different-view-in-context-menus-swiftui).